### PR TITLE
Fixed bug in attribute data script

### DIFF
--- a/R/setAttributes.R
+++ b/R/setAttributes.R
@@ -65,7 +65,7 @@ attribute_data <- function(df,info_df,miss_value = 0,averaging_buffer=NA) {
   df$cont_vals <- extract(info_df_ras, df[c("x", "y")], method="simple")
 
   # Check if there are missing values, if not then skip this
-  if(length(is.na(aux$surface_denisty)) != 0){
+  if(length(is.na(df$cont_vals)) != 0){
 
     # Now check if there is an averaging buffer when dealing with missing values
     if(!(is.na(averaging_buffer))){


### PR DESCRIPTION
There was an incorrectly designed if statement which meant that NA's were being returned from the function instead of being replaced by the missing value. This has now been fixed