### PR TITLE
Improvements and bug fixes to "Load_data" and "attribute_data"

### DIFF
--- a/R/setAttributes.R
+++ b/R/setAttributes.R
@@ -65,7 +65,7 @@ attribute_data <- function(df,info_df,miss_value = 0,averaging_buffer=NA) {
   df$cont_vals <- extract(info_df_ras, df[c("x", "y")], method="simple")
 
   # Check if there are missing values, if not then skip this
-  if(length(is.na(df$cont_vals)) != 0){
+  if(any(is.na(df$cont_vals))){
 
     # Now check if there is an averaging buffer when dealing with missing values
     if(!(is.na(averaging_buffer))){


### PR DESCRIPTION
Bug Fix to attribute data:

- Removes the hard coded element of the if loop when determining if NA values are to be filled with blanks

Load_data improvements:

- Fixed bug when loading multiple .TIF files and the spatial resolution when converting to data frames
- replaced the depreciated "fortify" function with "broom::tidy" when converting spatial polygons to data frames
- Fixed bug when thinning spatial polygons so they are now thinned by distances supplied (in metres). As opposed to doing after conversion to data table (where the topology of the spatial object is not always preserved)
